### PR TITLE
Docs+tests for public callbacks

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -629,7 +629,7 @@ public struct TranscriptionProgress {
     }
 }
 
-/// Callbacks to receive state updates during transcription.
+// Callbacks to receive state updates during transcription.
 
 /// A callback that provides transcription segments as they are discovered.
 /// - Parameters:

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -629,16 +629,46 @@ public struct TranscriptionProgress {
     }
 }
 
-public typealias SegmentDiscoveryCallback = (([TranscriptionSegment]) -> Void)
-public typealias ModelStateCallback = ((ModelState?, ModelState) -> Void)
-public typealias FractionCompletedCallback = ((Float) -> Void)
-public typealias TranscriptionPhaseCallback = ((TranscriptionPhase) -> Void)
+/// Callbacks to receive state updates during transcription.
 
-public enum TranscriptionPhase {
+/// A callback that provides transcription segments as they are discovered.
+/// - Parameters:
+///   - segments: An array of `TranscriptionSegment` objects representing the transcribed segments
+public typealias SegmentDiscoveryCallback = (_ segments: [TranscriptionSegment]) -> Void
+
+/// A callback that reports changes in the model's state.
+/// - Parameters:
+///   - oldState: The previous state of the model, if any
+///   - newState: The current state of the model
+public typealias ModelStateCallback = (_ oldState: ModelState?, _ newState: ModelState) -> Void
+
+/// A callback that reports changes in the transcription process.
+/// - Parameter state: The current `TranscriptionState` of the transcription process
+public typealias TranscriptionStateCallback = (_ state: TranscriptionState) -> Void
+
+/// Represents the different states of the transcription process.
+public enum TranscriptionState: CustomStringConvertible {
+    /// The audio is being converted to the required format for transcription
     case convertingAudio
+
+    /// The audio is actively being transcribed to text
     case transcribing
+
+    /// The transcription process has completed
     case finished
-} 
+
+    /// A human-readable description of the transcription state
+    public var description: String {
+        switch self {
+            case .convertingAudio:
+                return "Converting Audio"
+            case .transcribing:
+                return "Transcribing"
+            case .finished:
+                return "Finished"
+        }
+    }
+}
 
 /// Callback to receive progress updates during transcription.
 ///

--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -15,9 +15,8 @@ final class TranscribeTask {
     private let textDecoder: any TextDecoding
     private let tokenizer: any WhisperTokenizer
 
-    public var segmentDiscoveryCallback: (([TranscriptionSegment]) -> Void)?
-    public var fractionCompletedCallback: ((Float) -> Void)?
- 
+    public var segmentDiscoveryCallback: SegmentDiscoveryCallback?
+
     init(
         currentTimings: TranscriptionTimings,
         progress: Progress?,
@@ -117,9 +116,6 @@ final class TranscribeTask {
                 let timeOffsetEnd = Float(seek + segmentSize) / Float(WhisperKit.sampleRate)
                 Logging.debug("Decoding Seek: \(seek) (\(formatTimestamp(timeOffset))s)")
                 Logging.debug("Decoding Window Size: \(segmentSize) (\(formatTimestamp(timeOffsetEnd - timeOffset))s)")
-
-                let totalLength = Float(seekClipEnd)/Float(WhisperKit.sampleRate)
-                self.fractionCompletedCallback?(timeOffset / totalLength)
 
                 let audioProcessingStart = Date()
                 let clipAudioSamples = Array(audioArray[seek..<(seek + segmentSize)])

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -104,8 +104,7 @@ open class WhisperKit {
         prewarm: Bool? = nil,
         load: Bool? = nil,
         download: Bool = true,
-        useBackgroundDownloadSession: Bool = false,
-        modelStateDidChangeCallback: ModelStateCallback? = nil
+        useBackgroundDownloadSession: Bool = false
     ) async throws {
         let config = WhisperKitConfig(
             model: model,


### PR DESCRIPTION
Hi @iandundas wanted to get your thoughts on these changes:
1. Added some docs & tests for the callbacks
2. Removed fraction completed callback
	- This one in particular I'm curious about, we have a pretty good handler for fraction completed especially for VAD which is just the `whisperKit.progress.fractionCompleted`, however it only tracks the progress upon completion of a window. Did you need this so you would have a sense of the progress before its completed? If so we can add it back, or otherwise do the accounting ahead of time for the progress (before the transcription completed) - I think that would make sense and appear more "active" in the UI for concurrent transcription, i.e. the progress bar would move faster at the start, and slow down at the end, just wanted to confirm.
3. Removed the init parameter `, modelStateDidChangeCallback: ModelStateCallback? = nil`, this is something that should probably be in the config at a future time if its needed on init. I think I saw the reason for this - if the default `load: true` is used, the callback would be nil when setting up the models. In the test I set `load: false` in the config and then called `loadModels()` at after setting the callback. If this causes issues with your setup we can rework it into the WhisperKitConfig.
4. `SegmentDiscoveryCallback` - I tried for a bit to get the timeoffset passed into during concurrent transcription but had a hard time because the segments are all merged at the end to correct their timestamps. Can add this in a future PR with a little more thought, we'd need to either pass in an overall offset into the transcribetask, or track the offset in a separate property somehow.


I think that's the major stuff, let me know your thoughts and thanks for submitting this PR!